### PR TITLE
Add script for generate conda packages for nvmpi and ffmpeg with nvmpi codec support

### DIFF
--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -26,6 +26,7 @@ jobs:
           image: nvcr.io/nvidia/l4t-base:r35.1.0
           options: -v ${{ github.workspace }}:/work
           run: |
+            ## Install miniforge3
             apt -y update
             apt -y install curl
             curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
@@ -34,7 +35,14 @@ jobs:
             $CONDA_PREFIX/condabin/mamba install -y -n base conda-build anaconda-client conda-forge-pinning
             # Workaround for https://github.com/conda/conda-build/issues/4984
             $CONDA_PREFIX/condabin/mamba update -y -n base --all
+            ### Build nvmpi
             cd /work
             $CONDA_PREFIX/condabin/conda run -n base conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -c conda-forge nvmpi
+            ### Build ffmpeg with nvmpi patch
+            git clone -b jetson-ffmpeg https://github.dev/ami-iit/ffmpeg-feedstock
+            cp ./ffmpeg_patches/ffmpeg6.0_nvmpi.patch ./ffmpeg-feedstock/recipe/patches
+            # Build ffmpeg gpl variant
+            $CONDA_PREFIX/condabin/conda run -n base conda build -m ./ffmpeg-feedstock/.ci_support/linux_aarch64_license_familygpl.yaml -c conda-forge -c local ./ffmpeg-feedstock/recipe
+            # Build ffmpeg lgpl variant
+            $CONDA_PREFIX/condabin/conda run -n base conda build -m ./ffmpeg-feedstock/.ci_support/linux_aarch64_license_familylgpl.yaml -c conda-forge -c local ./ffmpeg-feedstock/recipe
 
-            

--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -31,7 +31,9 @@ jobs:
             curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
             export CONDA_PREFIX=/root/miniforge3
             bash Miniforge3-$(uname)-$(uname -m).sh -b -p $CONDA_PREFIX
-            $CONDA_PREFIX/condabin/conda install -n base conda-build anaconda-client conda-forge-pinning
+            $CONDA_PREFIX/condabin/mamba install -n base conda-build anaconda-client conda-forge-pinning
+            # Workaround for https://github.com/conda/conda-build/issues/4984
+            $CONDA_PREFIX/condabin/mamba update -n base --all
             cd /work
             $CONDA_PREFIX/condabin/conda run -n base conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -c conda-forge nvmpi
 

--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -35,6 +35,6 @@ jobs:
             # Workaround for https://github.com/conda/conda-build/issues/4984
             $CONDA_PREFIX/condabin/mamba update -y -n base --all
             cd /work
-            $CONDA_PREFIX/condabin/conda run -n base conda build -y -m ${CONDA_PREFIX}/conda_build_config.yaml -c conda-forge nvmpi
+            $CONDA_PREFIX/condabin/conda run -n base conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -c conda-forge nvmpi
 
             

--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -43,12 +43,12 @@ jobs:
             $CONDA_PREFIX/condabin/conda run -n base conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -c conda-forge nvmpi
             ### Build ffmpeg with nvmpi patch
             git clone -b jetson-ffmpeg https://github.com/ami-iit/ffmpeg-feedstock
-            git clone https://github.com/madsciencetist/jetson-ffmpeg
+            git clone https://github.com/traversaro/jetson-ffmpeg
             cd jetson-ffmpeg
             # Make sure that this sha is coherent with the one used in nvmpi/meta.yaml
-            git checkout 4a33a2cca94970c92340191cdcc016a1636e39ad
+            git checkout addffmpeg61
             cd ..
-            cp ./jetson-ffmpeg/ffmpeg_patches/ffmpeg6.0_nvmpi.patch ./ffmpeg-feedstock/recipe/patches
+            cp ./jetson-ffmpeg/ffmpeg_patches/ffmpeg6.1_nvmpi.patch ./ffmpeg-feedstock/recipe/patches
             # Build ffmpeg gpl variant
             $CONDA_PREFIX/condabin/conda run -n base conda build -m ./ffmpeg-feedstock/.ci_support/linux_aarch64_license_familygpl.yaml -c conda-forge -c local ./ffmpeg-feedstock/recipe
             # Build ffmpeg lgpl variant

--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -31,10 +31,10 @@ jobs:
             curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
             export CONDA_PREFIX=/root/miniforge3
             bash Miniforge3-$(uname)-$(uname -m).sh -b -p $CONDA_PREFIX
-            $CONDA_PREFIX/condabin/mamba install -n base conda-build anaconda-client conda-forge-pinning
+            $CONDA_PREFIX/condabin/mamba install -y -n base conda-build anaconda-client conda-forge-pinning
             # Workaround for https://github.com/conda/conda-build/issues/4984
-            $CONDA_PREFIX/condabin/mamba update -n base --all
+            $CONDA_PREFIX/condabin/mamba update -y -n base --all
             cd /work
-            $CONDA_PREFIX/condabin/conda run -n base conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -c conda-forge nvmpi
+            $CONDA_PREFIX/condabin/conda run -n base conda build -y -m ${CONDA_PREFIX}/conda_build_config.yaml -c conda-forge nvmpi
 
             

--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -2,8 +2,8 @@ name: CI Workflow
 
 on:
   push:
-#    branches:
-#      - master
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:
@@ -57,5 +57,4 @@ jobs:
             # List created packages
             cd /work/conda-bld/linux-aarch64/
             ls *.tar.bz2
-            anaconda upload --skip-existing *.tar.bz2
-
+            $CONDA_PREFIX/condabin/conda run -n base anaconda upload --skip-existing *.tar.bz2

--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -42,7 +42,7 @@ jobs:
             cd /work
             $CONDA_PREFIX/condabin/conda run -n base conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -c conda-forge nvmpi
             ### Build ffmpeg with nvmpi patch
-            git clone -b jetson-ffmpeg https://github.dev/ami-iit/ffmpeg-feedstock
+            git clone -b jetson-ffmpeg https://github.com/ami-iit/ffmpeg-feedstock
             git clone https://github.com/madsciencetist/jetson-ffmpeg
             cd jetson-ffmpeg
             # Make sure that this sha is coherent with the one used in nvmpi/meta.yaml

--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -2,12 +2,13 @@ name: CI Workflow
 
 on:
   push:
-  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
 
 jobs:
   build_conda_packages:
 
-  
     name: Build conda packages
     runs-on: ubuntu-22.04
 
@@ -24,7 +25,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: nvcr.io/nvidia/l4t-jetpack:r35.3.1
-          options: -v ${{ github.workspace }}:/work
+          options: -v ${{ github.workspace }}:/work --env ANACONDA_API_TOKEN=${{ secrets.ANACONDA_API_TOKEN }}
           run: |
             ## Ensure conda-build put generated packages in a place that can be accessed from the host
             mkdir /work/conda-bld
@@ -53,4 +54,8 @@ jobs:
             $CONDA_PREFIX/condabin/conda run -n base conda build -m ./ffmpeg-feedstock/.ci_support/linux_aarch64_license_familygpl.yaml -c conda-forge -c local ./ffmpeg-feedstock/recipe
             # Build ffmpeg lgpl variant
             $CONDA_PREFIX/condabin/conda run -n base conda build -m ./ffmpeg-feedstock/.ci_support/linux_aarch64_license_familylgpl.yaml -c conda-forge -c local ./ffmpeg-feedstock/recipe
+            # List created packages
+            cd /work/conda-bld/linux-aarch64/
+            ls *.tar.bz2
+            anaconda upload --skip-existing *.tar.bz2
 

--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -2,8 +2,8 @@ name: CI Workflow
 
 on:
   push:
-    branches:
-      - master
+#    branches:
+#      - master
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -51,9 +51,9 @@ jobs:
             cd ..
             cp ./jetson-ffmpeg/ffmpeg_patches/ffmpeg6.1_nvmpi.patch ./ffmpeg-feedstock/recipe/patches
             # Build ffmpeg gpl variant
-            $CONDA_PREFIX/condabin/conda run -n base conda build -m ./ffmpeg-feedstock/.ci_support/linux_aarch64_license_familygpl.yaml -c conda-forge -c local ./ffmpeg-feedstock/recipe
+            $CONDA_PREFIX/condabin/conda run -n base conda build --no-test -m ./ffmpeg-feedstock/.ci_support/linux_aarch64_license_familygpl.yaml -c conda-forge -c local ./ffmpeg-feedstock/recipe
             # Build ffmpeg lgpl variant
-            $CONDA_PREFIX/condabin/conda run -n base conda build -m ./ffmpeg-feedstock/.ci_support/linux_aarch64_license_familylgpl.yaml -c conda-forge -c local ./ffmpeg-feedstock/recipe
+            $CONDA_PREFIX/condabin/conda run -n base conda build --no-test -m ./ffmpeg-feedstock/.ci_support/linux_aarch64_license_familylgpl.yaml -c conda-forge -c local ./ffmpeg-feedstock/recipe
             # List created packages
             cd /work/conda-bld/linux-aarch64/
             ls *.tar.bz2

--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -1,0 +1,39 @@
+name: CI Workflow
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  apt_build:
+
+  
+    name: Install package dependencies
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
+      - name: Run the build process with Docker
+        uses: addnab/docker-run-action@v3
+        with:
+          image: nvcr.io/nvidia/l4t-base:r35.1.0
+          options: -v ${{ github.workspace }}:/work
+          run: |
+            apt -y update
+            apt -y upgrade
+            apt install curl
+            curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+            bash Miniforge3-$(uname)-$(uname -m).sh
+            ~/miniforge3/condabin/conda install conda-build anaconda-client conda-forge-pinning
+            export CONDA_PREFIX=~/miniforge3
+            cd /work
+            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -c conda-forge nvmpi
+
+            

--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -40,7 +40,12 @@ jobs:
             $CONDA_PREFIX/condabin/conda run -n base conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -c conda-forge nvmpi
             ### Build ffmpeg with nvmpi patch
             git clone -b jetson-ffmpeg https://github.dev/ami-iit/ffmpeg-feedstock
-            cp ./ffmpeg_patches/ffmpeg6.0_nvmpi.patch ./ffmpeg-feedstock/recipe/patches
+            git clone https://github.com/madsciencetist/jetson-ffmpeg
+            cd jetson-ffmpeg
+            # Make sure that this sha is coherent with the one used in nvmpi/meta.yaml
+            git checkout 4a33a2cca94970c92340191cdcc016a1636e39ad
+            cd ..
+            cp ./jetson-ffmpeg/ffmpeg_patches/ffmpeg6.0_nvmpi.patch ./ffmpeg-feedstock/recipe/patches
             # Build ffmpeg gpl variant
             $CONDA_PREFIX/condabin/conda run -n base conda build -m ./ffmpeg-feedstock/.ci_support/linux_aarch64_license_familygpl.yaml -c conda-forge -c local ./ffmpeg-feedstock/recipe
             # Build ffmpeg lgpl variant

--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -23,12 +23,12 @@ jobs:
       - name: Run the build process with Docker
         uses: addnab/docker-run-action@v3
         with:
-          image: nvcr.io/nvidia/l4t-base:r35.1.0
+          image: nvcr.io/nvidia/l4t-jetpack:r35.3.1
           options: -v ${{ github.workspace }}:/work
           run: |
             ## Install miniforge3
             apt -y update
-            apt -y install curl
+            apt -y install curl git
             curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
             export CONDA_PREFIX=/root/miniforge3
             bash Miniforge3-$(uname)-$(uname -m).sh -b -p $CONDA_PREFIX

--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -27,13 +27,12 @@ jobs:
           options: -v ${{ github.workspace }}:/work
           run: |
             apt -y update
-            apt -y upgrade
             apt -y install curl
             curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
-            bash Miniforge3-$(uname)-$(uname -m).sh -b -p $HOME/miniforge3
-            export CONDA_PREFIX=~/miniforge3
-            $CONDA_PREFIX/condabin/conda install conda-build anaconda-client conda-forge-pinning
+            export CONDA_PREFIX=/root/miniforge3
+            bash Miniforge3-$(uname)-$(uname -m).sh -b -p $CONDA_PREFIX
+            $CONDA_PREFIX/condabin/conda -n base install conda-build anaconda-client conda-forge-pinning
             cd /work
-            conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -c conda-forge nvmpi
+            $CONDA_PREFIX/condabin/conda run -n base conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -c conda-forge nvmpi
 
             

--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -26,6 +26,9 @@ jobs:
           image: nvcr.io/nvidia/l4t-jetpack:r35.3.1
           options: -v ${{ github.workspace }}:/work
           run: |
+            ## Ensure conda-build put generated packages in a place that can be accessed from the host
+            mkdir /work/conda-bld
+            export CONDA_BLD_PATH=/work/conda-bld
             ## Install miniforge3
             apt -y update
             apt -y install curl git

--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -5,10 +5,10 @@ on:
   pull_request:
 
 jobs:
-  apt_build:
+  build_conda_packages:
 
   
-    name: Install package dependencies
+    name: Build conda packages
     runs-on: ubuntu-22.04
 
     steps:
@@ -28,7 +28,7 @@ jobs:
           run: |
             apt -y update
             apt -y upgrade
-            apt install curl
+            apt -y install curl
             curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
             bash Miniforge3-$(uname)-$(uname -m).sh
             ~/miniforge3/condabin/conda install conda-build anaconda-client conda-forge-pinning

--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -31,7 +31,7 @@ jobs:
             curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
             export CONDA_PREFIX=/root/miniforge3
             bash Miniforge3-$(uname)-$(uname -m).sh -b -p $CONDA_PREFIX
-            $CONDA_PREFIX/condabin/conda -n base install conda-build anaconda-client conda-forge-pinning
+            $CONDA_PREFIX/condabin/conda install -n base conda-build anaconda-client conda-forge-pinning
             cd /work
             $CONDA_PREFIX/condabin/conda run -n base conda build -m ${CONDA_PREFIX}/conda_build_config.yaml -c conda-forge nvmpi
 

--- a/.github/workflows/build_conda_packages.yaml
+++ b/.github/workflows/build_conda_packages.yaml
@@ -30,9 +30,9 @@ jobs:
             apt -y upgrade
             apt -y install curl
             curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
-            bash Miniforge3-$(uname)-$(uname -m).sh
-            ~/miniforge3/condabin/conda install conda-build anaconda-client conda-forge-pinning
+            bash Miniforge3-$(uname)-$(uname -m).sh -b -p $HOME/miniforge3
             export CONDA_PREFIX=~/miniforge3
+            $CONDA_PREFIX/condabin/conda install conda-build anaconda-client conda-forge-pinning
             cd /work
             conda mambabuild -m ${CONDA_PREFIX}/conda_build_config.yaml -c conda-forge nvmpi
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # jetson-ffmpeg-conda-package-builder
-Conda package builder for ffmpeg-jetson
+
+> [!IMPORTANT]  
+> **The `jetson-ffmpeg` channel is currently untested, and may not work.**
+
+This repo contains scripts and documentation related to the **untested** [`jetson-ffmpeg`](https://anaconda.org/jetson-ffmpeg) conda channel. This channel provides [`conda-forge`]()-compatible builds of ffmpeg, with the additional `<..>_nvmpi` codecs to support hardware-accelerated encoding and decoding on NVIDIA Jetson systems, using the [`l4t-multimedia`](https://docs.nvidia.com/jetson/l4t-multimedia/) Jetpack-specific API. This repo only packages for conda the software developed in the following repos:
+* [https://github.com/jocover/jetson-ffmpeg](https://github.com/jocover/jetson-ffmpeg)
+* [https://github.com/Keylost/jetson-ffmpeg](https://github.com/Keylost/jetson-ffmpeg)
+* [https://github.com/madsciencetist/jetson-ffmpeg](https://github.com/madsciencetist/jetson-ffmpeg)
+
+
+## Install
+
+> [!IMPORTANT]  
+> **Do not install this packages on non-Jetson systems, as otherwise ffmpeg will fail due to the missing `l4t`-related libraries.**
+
+> [!IMPORTANT]  
+> **The packages in the ``jetson-ffmpeg` conda channel are meant to be used together with dependencies provided by `conda-forge`  channel.**
+
+To use the packages contained in the [`jetson-ffmpeg`](https://anaconda.org/jetson-ffmpeg), just add the `jetson-ffmpeg` to the channel used to create your conda environent, with a higher priority w.r.t. `conda-forge`, and then install `ffmpeg=*=*jetsonffmpeg*` . For example, if you want to create an environent with `opencv` and ffmpeg with jetson support, run:
+~~~
+conda create -n opencvjetson -c jetson-ffmpeg -c conda-forge opencv ffmpeg=*=*jetsonffmpeg*
+~~~
+
+It is important to make sure that `jetson-ffmpeg` has higher priority w.r.t. to `conda-forge`, as the `ffmpeg` package contained in this channel is a drop-in replacement for the one provided by `conda-forge` .

--- a/nvmpi/build.sh
+++ b/nvmpi/build.sh
@@ -4,7 +4,7 @@ LD_LIBRARY_PATH=$(pwd)/stubs:$LD_LIBRARY_PATH
 
 mkdir build && cd build
 
-cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX \
+cmake -GNinja ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX \
       -DCMAKE_PREFIX_PATH=$PREFIX \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=ON \

--- a/nvmpi/build.sh
+++ b/nvmpi/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+LD_LIBRARY_PATH=$(pwd)/stubs:$LD_LIBRARY_PATH
+
+mkdir build && cd build
+
+cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=ON \
+      $SRC_DIR
+
+ninja
+ninja install

--- a/nvmpi/meta.yaml
+++ b/nvmpi/meta.yaml
@@ -6,6 +6,7 @@ package:
   version: {{ version }}
 
 source:
+  # Make sure that this sha is coherent with the one used .github/workflows/build_conda_packages.yaml
   - url: https://github.com/madsciencetist/jetson-ffmpeg/archive/4a33a2cca94970c92340191cdcc016a1636e39ad.zip
     sha256: 01185ec2e1795178cc2e227b2055d2bd4bebcfc17544759c83a9d1951516d472
 

--- a/nvmpi/meta.yaml
+++ b/nvmpi/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   run_exports:
-    - {{ pin_subpackage(nvmpi, max_pin='x.x.x') }}
+    - {{ pin_subpackage(name, max_pin='x.x.x') }}
 
 requirements:
   build:

--- a/nvmpi/meta.yaml
+++ b/nvmpi/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "nvmpi" %}
+{% set version = "2023.11.13" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/madsciencetist/jetson-ffmpeg/archive/4a33a2cca94970c92340191cdcc016a1636e39ad.zip
+    sha256: d3f84f1e2632c15a3892dc6c89f0cd6b4137e990b8aef8fe245cd8e75fbb5388
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(nvmpi, max_pin='x.x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - ninja
+    - cmake
+
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/nvmpi.h  # [linux]
+    - test -f ${PREFIX}/lib/libnvmpi.so  # [linux]
+    - test -f ${PREFIX}/lib/pkgconfig/nvmpi.pc  # [linux]
+
+about:
+  home: https://github.com/madsciencetist/jetson-ffmpeg
+  license: MIT
+  license_file: LICENSE
+  summary: nvmpi
+
+extra:
+  recipe-maintainers:
+    - traversaro

--- a/nvmpi/meta.yaml
+++ b/nvmpi/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://github.com/madsciencetist/jetson-ffmpeg/archive/4a33a2cca94970c92340191cdcc016a1636e39ad.zip
-    sha256: d3f84f1e2632c15a3892dc6c89f0cd6b4137e990b8aef8fe245cd8e75fbb5388
+    sha256: 01185ec2e1795178cc2e227b2055d2bd4bebcfc17544759c83a9d1951516d472
 
 build:
   number: 0


### PR DESCRIPTION
This PR adds a GitHub Actions script to generate the `nvmpi` package and a modified `ffmpeg` package to perform hardware-accelerater video encoding and decoding based on the software in https://github.com/madsciencetist/jetson-ffmpeg .